### PR TITLE
`mkdir()` tests existing path is directory (not file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 ## Unreleased
 
 
+### Fixed
+
+-   `mkdir()` results in an "EEXIST" error if the existing path is a file
+
+    -   no "EEXIST" error if the existing path is a directory
+
+
 ## 1.1.0 - 2016-09-28
 
 

--- a/lib/mkdir.js
+++ b/lib/mkdir.js
@@ -21,11 +21,18 @@ function mkdir (
 
   fn((err) => {
     if (typeof callback === 'function') {
-      if (err && err.code !== EEXIST) {
-        callback(err)
-      } else {
-        callback(null)
+      if (err && err.code === EEXIST) {
+        fs.stat(path, (statErr, stat) => {
+          if (statErr) {
+            callback(statErr)
+            return
+          }
+          callback(stat.isDirectory() ? null : err)
+          return
+        })
+        return
       }
+      callback(err)
     }
   })
 }
@@ -34,9 +41,12 @@ function mkdirSync (path /* : string */, mode /* :? number */) {
   try {
     fs.mkdirSync(path, mode)
   } catch (err) {
-    if (err.code !== EEXIST) {
-      throw err
+    if (err.code === EEXIST) {
+      if (fs.statSync(path).isDirectory()) {
+        return
+      }
     }
+    throw err
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idempotent-fs",
-  "description": "`fs.unlink()` that _won't_ throw if the file is missing + other outcome-aware Node.js \"fs\" functions",
+  "description": "fs.unlink() that won't throw if the file is missing + other outcome-aware Node.js fs functions",
   "version": "1.1.0",
   "bugs": {
     "url": "https://github.com/jokeyrhyme/idempotent-fs.js/issues"

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -17,6 +17,16 @@ test('mkdirSync() on existing directory', (t) => {
   })
 })
 
+const EXISTING_FILE = __filename
+
+asyncHelper.assertAsyncError(test, lib.mkdir, [ EXISTING_FILE ], 'mkdir() on existing file')
+
+test('mkdirSync() on existing file', (t) => {
+  t.throws(() => {
+    lib.mkdirSync(EXISTING_FILE)
+  })
+})
+
 const NESTED_MISSING_DIRECTORY = path.join(__dirname, 'missing', 'missing')
 
 asyncHelper.assertAsyncError(test, lib.mkdir, [ NESTED_MISSING_DIRECTORY ], 'mkdir() on missing directory within missing directory')


### PR DESCRIPTION
### Fixed

-   `mkdir()` results in an "EEXIST" error if the existing path is a file

    -   no "EEXIST" error if the existing path is a directory