### PR TITLE
`mkdir()` now internally uses mkdirp

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,10 @@
 {
   "extends": [
     "eslint:recommended",
+    "plugin:node/recommended",
     "standard"
+  ],
+  "plugins": [
+    "node"
   ]
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,2 +1,11 @@
 [ignore]
-.*/node_modules/\.cache/.*
+<PROJECT_ROOT>/.nyc_output/.*
+<PROJECT_ROOT>/build/.*
+<PROJECT_ROOT>/coverage/.*
+<PROJECT_ROOT>/dist/.*
+<PROJECT_ROOT>/node_modules/babel.*
+<PROJECT_ROOT>/node_modules/y18n/test/.*
+<PROJECT_ROOT>/node_modules/\.cache/.*
+
+[options]
+suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 node_js:
   - '4'
   - '6'
+  - '7'
 env:
   global:
     - CXX=g++-4.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ## Unreleased
 
 
+### Changed
+
+-   `mkdir()` now internally uses [mkdirp](https://github.com/substack/node-mkdirp)
+
+
 ### Fixed
 
 -   `mkdir()` results in an "EEXIST" error if the existing path is a file

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ See the [upstream `mkdir()` and `mkdirSync`](https://nodejs.org/dist/latest-v6.x
 
 -   **Changed**: No "EEXIST" error. Trying to `mkdir()` a directory that already exists is not an error. Mission accomplished!
 
+-   **Changed**: internally uses [mkdirp](https://github.com/substack/node-mkdirp)
+
 
 ### `rmdir()` and `rmdirSync()`
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,12 @@ environment:
   matrix:
     - nodejs_version: '4'
     - nodejs_version: '6'
+    - nodejs_version: '7'
 install:
-  - ps: 'Install-Product node $env:nodejs_version'
+  - ps: 'Install-Product node $env:nodejs_version x64'
   - npm install
 test_script:
   - node --version
   - npm --version
   - npm test
-cache:
-  - node_modules
+cache: []

--- a/lib/mkdir.js
+++ b/lib/mkdir.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const fs = require('graceful-fs')
+const mkdirp = require('mkdirp')
 const pify = require('pify')
 
 const EEXIST = 'EEXIST'
@@ -13,10 +14,10 @@ function mkdir (
 ) {
   let fn
   if (typeof mode === 'function') {
-    fn = fs.mkdir.bind(fs, path)
+    fn = mkdirp.bind(null, path, { fs })
     callback = mode
   } else {
-    fn = fs.mkdir.bind(fs, path, mode)
+    fn = mkdirp.bind(null, path, { fs, mode })
   }
 
   fn((err) => {
@@ -39,7 +40,7 @@ function mkdir (
 
 function mkdirSync (path /* : string */, mode /* :? number */) {
   try {
-    fs.mkdirSync(path, mode)
+    mkdirp.sync(path, { fs, mode })
   } catch (err) {
     if (err.code === EEXIST) {
       if (fs.statSync(path).isDirectory()) {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "idempotent-fs",
   "description": "fs.unlink() that won't throw if the file is missing + other outcome-aware Node.js fs functions",
   "version": "1.1.0",
+  "author": "Ron Waldon <jokeyrhyme@gmail.com> (https://github.com/jokeyrhyme)",
   "bugs": {
     "url": "https://github.com/jokeyrhyme/idempotent-fs.js/issues"
   },
@@ -12,13 +13,17 @@
   },
   "devDependencies": {
     "ava": "^0.16.0",
-    "eslint": "^3.6.1",
-    "eslint-config-standard": "^6.1.0",
-    "eslint-plugin-promise": "^3.0.0",
-    "eslint-plugin-standard": "^2.0.0",
+    "eslint": "^3.9.0",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-node": "^2.1.3",
+    "eslint-plugin-promise": "^3.3.0",
+    "eslint-plugin-standard": "^2.0.1",
     "fixpack": "^2.3.1",
     "flow-bin": "^0.34.0",
     "nyc": "^8.3.0"
+  },
+  "directories": {
+    "test": "test"
   },
   "engines": {
     "node": ">=4",
@@ -44,7 +49,7 @@
     "ava": "nyc ava",
     "eslint": "eslint --fix --cache .",
     "fixpack": "fixpack",
-    "flow_check": "flow check || exit 0",
+    "flow_check": "flow check",
     "nyc": "nyc check-coverage",
     "posttest": "npm run eslint && npm run flow_check && npm run fixpack",
     "test": "npm run ava && npm run nyc"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "graceful-fs": "*",
+    "mkdirp": "^0.5.1",
     "pify": "^2.3.0"
   },
   "devDependencies": {

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "../.eslintrc.json"
+  ],
+  "rules": {
+    "node/no-unpublished-require": 0
+  }
+}

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -29,10 +29,10 @@ test('mkdirSync() on existing file', (t) => {
 
 const NESTED_MISSING_DIRECTORY = path.join(__dirname, 'missing', 'missing')
 
-asyncHelper.assertAsyncError(test, lib.mkdir, [ NESTED_MISSING_DIRECTORY ], 'mkdir() on missing directory within missing directory')
+asyncHelper.assertAsyncNoError(test, lib.mkdir, [ NESTED_MISSING_DIRECTORY ], 'mkdir() on missing directory within missing directory')
 
 test('mkdirSync() on missing directory within missing directory', (t) => {
-  t.throws(() => {
+  t.notThrows(() => {
     lib.mkdirSync(NESTED_MISSING_DIRECTORY)
   })
 })

--- a/test/rmdir.js
+++ b/test/rmdir.js
@@ -17,14 +17,22 @@ test('rmdirSync() on missing directory', (t) => {
   })
 })
 
+const FILE_PATH = __filename
 if (process.platform.indexOf('win') !== 0) {
   // https://github.com/nodejs/node/issues/8797
-  const FILE_PATH = __filename
 
   asyncHelper.assertAsyncError(test, lib.rmdir, [ FILE_PATH ], 'rmdir() on file instead of directory')
 
   test('rmdirSync() on file instead of directory', (t) => {
     t.throws(() => {
+      lib.rmdirSync(FILE_PATH)
+    })
+  })
+} else {
+  asyncHelper.assertAsyncNoError(test, lib.rmdir, [ FILE_PATH ], 'rmdir() on file instead of directory')
+
+  test('rmdirSync() on file instead of directory', (t) => {
+    t.notThrows(() => {
       lib.rmdirSync(FILE_PATH)
     })
   })


### PR DESCRIPTION
### Changed

-   `mkdir()` now internally uses [mkdirp](https://github.com/substack/node-mkdirp)

